### PR TITLE
Task: Metrics and Unbounded Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+- Fixes issues when passing requests through an unbounded throttle (`bytesPerSecond` = `Infinity`).
+- Adds public `onThroughputMetrics` metrics callback to the `BandwidthThrottleGroup`.
+
 # 1.0.1
 
 - Fixes issues on subsequent throttled requests in a group.

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -3,6 +3,8 @@ import IConfig from './Interfaces/IConfig.ts';
 class Config implements IConfig {
     public bytesPerSecond: number = Infinity;
     public ticksPerSecond: number = 40;
+    public throughputSampleIntervalMs: number = 1000;
+    public throughputSampleSize: number = 4;
 
     public get isThrottled(): boolean {
         return this.bytesPerSecond < Infinity;

--- a/lib/Interfaces/IConfig.ts
+++ b/lib/Interfaces/IConfig.ts
@@ -22,6 +22,23 @@ interface IConfig {
      */
 
     ticksPerSecond?: number;
+
+    /**
+     * The frequency of samples used to determine the `averageBytesPerSecond` metric.
+     *
+     * @default 1000
+     */
+
+    throughputSampleIntervalMs?: number;
+
+    /**
+     * The maximum number of samples that should contribute to the
+     * `averageBytesPerSecond` metric rolling average.
+     *
+     * @default 4
+     */
+
+    throughputSampleSize?: number;
 }
 
 export default IConfig;

--- a/lib/Interfaces/IThroughputData.ts
+++ b/lib/Interfaces/IThroughputData.ts
@@ -1,0 +1,17 @@
+interface IThroughputData {
+    /**
+     * The average throughput, calculated as the mean of `config.throughputSampleSize` samples,
+     * with samples taken every `config.throughputSampleIntervalMs`.
+     */
+
+    averageBytesPerSecond: number;
+
+    /**
+     * A percentage (between 0 and 1) indicating amount of bandwidth utilised by the throttle
+     * group. Calculated by dividing `config.bytesPerSecond` by `averageBytesPerSecond`.
+     */
+
+    utilization: number;
+}
+
+export default IThroughputData;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "bandwidth-throttle-stream",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bandwidth-throttle-stream",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A Node.js and Deno transform stream for throttling bandwidth",
     "author": "KunkaLabs Limited",
     "private": false,


### PR DESCRIPTION
- Fixes issues when passing requests through an unbounded throttle (`bytesPerSecond` = `Infinity`).
- Adds public `onThroughputMetrics` metrics callback to the `BandwidthThrottleGroup`.